### PR TITLE
Fix grammatical errors in theme switcher page instructions

### DIFF
--- a/app/quick-start/theme-setting/markdown.ts
+++ b/app/quick-start/theme-setting/markdown.ts
@@ -3,7 +3,8 @@ export const markdown = `
 
 Developers love dark theme but setting up the theme can be very hectic for the developers as when there are many components in your app and you have to pass your theme props very deep in the component tree where things can become ambigous.
 
-With the help of jotai you can setup different themes for you app in minutes. Let's take a look at this,
+With the help of jotai, you can setup different themes for your app in minutes. Let's take a look at this:
+
 Initialize a theme atom with a default value. 
 
 ~~~js


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed
Fixed the grammatical errors in the instructions for setting up different themes using Jotai. The original text contained a few mistakes.

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
### Before
![image](https://github.com/jotaijs/jotai-tutorial/assets/36098718/e279e38d-0b22-4b1e-8f52-a02846ca497c)

### After
![image](https://github.com/jotaijs/jotai-tutorial/assets/36098718/9969523e-3401-485b-8bb1-db656115cf5e)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
