### PR TITLE
Fix a typo in async-read-atoms guide

### DIFF
--- a/app/quick-start/async-read-atoms/markdown.ts
+++ b/app/quick-start/async-read-atoms/markdown.ts
@@ -22,7 +22,7 @@ Jotai is inherently leveraging \`Suspense\` to handle asynchronous flows.
 </Suspense>
 ~~~
 
-But there is a more jotai way of doing this with the \`loadable api\` present in \`jotai/utils\`. By simply wrapping the atom in loadable util and it returns the value with one of the three states: \`loadable\`, \`hasData\` and \`hasError\`.
+But there is a more jotai way of doing this with the \`loadable api\` present in \`jotai/utils\`. By simply wrapping the atom in loadable util and it returns the value with one of the three states: \`loading\`, \`hasData\` and \`hasError\`.
 
 ~~~js
 {


### PR DESCRIPTION
## Changes proposed

In the async-read-atoms tutorial's description, one of the values for `loadable` atom's status is incorrect.

## Check List

- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

![image](https://github.com/molokovev/jotai-tutorial/assets/9248122/4e9bdf55-6049-424d-ba85-9cc1e7efca66)
